### PR TITLE
Add a note about iptables rules not being saved

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ See :
  
 * https://github.com/bitintheskud/ansible-role-docker-ce-centos.git
 
+## Caveats
+
+This role sets up the AWS ECS agent as recommended in the documentation, including adding iptables rules. However, bear in mind that this role will not handle saving the iptables rules for you (via `iptables-save` or other means). If you wish to save iptables rules to disk so they will survive a reboot and be present without an additional Ansible run, you should handle that outside of this role.
+
 ## Example Playbook
 
 ```yaml


### PR DESCRIPTION
Don't know if this is the best place for the note -- but I found this to be non-obvious behavior (even knowing the behavior of Ansible's iptables module). The way I'm using this role, it builds an image, and then runs again later, after a reboot. So between those two runs, the iptables rules get deleted unless saved outside the role, and AWS metadata/IAM role calls won't work from inside containers. Not a big deal, but I thought it was worth calling out so hopefully others could avoid this type of pitfall.

Thank you!