### PR TITLE
add ECS_RESERVED_MEMORY

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,3 +13,4 @@ ecs_agent_reserved_ports: "[22, 2375, 2376, 51678]"
 ecs_agent_container_stop_timeout: 30s
 ecs_agent_auth_type: ""
 ecs_agent_auth_data: ""
+ecs_agent_reserved_memory: 0

--- a/templates/ecs.j2
+++ b/templates/ecs.j2
@@ -5,3 +5,4 @@ ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST={{ ecs_agent_enable_task_iam_role_network_
 ECS_LOGFILE={{ ecs_agent_log_file }}
 ECS_AVAILABLE_LOGGING_DRIVERS=["json-file","awslogs"]
 ECS_LOGLEVEL={{ ecs_agent_loglevel }}
+ECS_RESERVED_MEMORY={{ ecs_agent_reserved_memory }}


### PR DESCRIPTION
Default of 0 matches AWS docs. https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html